### PR TITLE
Issue #2: Add JaCoCo Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,49 @@ jobs:
       - name: Validate with checkstyle
         run: mvn checkstyle:checkstyle
         working-directory: ./backend
+  
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run Tests
+        run: mvn test
+        working-directory: ./backend
+
+      - name: Upload Target Folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: target-folder
+          path: ./backend/target
+
+  jacoco:
+    runs-on: ubuntu-latest
+    needs: test
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Download Target Folder
+        uses: actions/download-artifact@v3
+        with:
+          name: target-folder
+          path: ./backend/target
+
+      - name: Run JaCoCo Check
+        run: mvn jacoco:check
+        working-directory: ./backend

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,52 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <rule>
+                            <element>BUNDLE</element>
+                            <limits>
+                                <limit>
+                                    <counter>INSTRUCTION</counter>
+                                    <value>COVEREDRATIO</value>
+                                    <minimum>0.60</minimum>
+                                </limit>
+                            </limits>
+                        </rule>
+                    </rules>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.5.0</version>
                 <executions>


### PR DESCRIPTION
closes #2 

This pull request introduces new testing and code coverage workflows to the project. The main changes include adding new jobs to the GitHub Actions workflow and configuring Maven plugins for running tests and generating code coverage reports.

### GitHub Actions Workflow Enhancements:
* Added a `test` job to run unit tests using Maven (`mvn test`) on the backend directory.
* Added a `jacoco` job to generate and check code coverage reports using the JaCoCo Maven plugin. This job depends on the `test` job.

### Maven Plugin Configurations:
* Added the `maven-surefire-plugin` to the `backend/pom.xml` to facilitate running tests.
* Added the `jacoco-maven-plugin` to the `backend/pom.xml` to generate code coverage reports and enforce minimum coverage rules.